### PR TITLE
Add mingwpy page from numpy.wiki

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -53,4 +53,11 @@ Glossary
         archives of compiler object files).  See also the `binutils wikipedia
         page`_.
 
+
+    LTO
+    Link-time optimization
+        See: `GCC LTO <https://gcc.gnu.org/wiki/LinkTimeOptimization>`_;
+        `interprocedural optimization
+        <https://en.wikipedia.org/wiki/Interprocedural_optimization>`_.
+
 .. include:: links_names.inc

--- a/index.rst
+++ b/index.rst
@@ -17,11 +17,12 @@ Contents
 ********
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     motivation
     background
     issues
+    mingwpy
     glossary
 
 .. hidden toctree suppresses warnings about not-included documents

--- a/links_names.inc
+++ b/links_names.inc
@@ -14,6 +14,9 @@
    http://sourceforge.net/p/mingw-w64/wiki2/Exception%20Handling/
 .. _SO post on mingw-w64 exception handling:
    http://stackoverflow.com/questions/15670169/what-is-difference-between-sjlj-vs-dwarf-vs-seh
+.. _mingwpy bitbucket repo:
+   https://bitbucket.org/carlkl/mingw-w64-for-python/downloads
+.. _mingwpy anaconda site: https://anaconda.org/carlkl/mingwpy
 
 .. Windows
 .. _PE format:

--- a/links_names.inc
+++ b/links_names.inc
@@ -22,6 +22,7 @@
 .. _PE: https://en.wikipedia.org/wiki/Portable_Executable
 .. _Structured exception handling:
 .. _SEH: https://www.microsoft.com/msj/0197/exception/exception.aspx
+.. _Windows DLL notes: https://github.com/numpy/numpy/wiki/windows-dll-notes
 
 .. Documentation
 .. _sphinx: http://sphinx-doc.org

--- a/mingwpy.rst
+++ b/mingwpy.rst
@@ -15,8 +15,9 @@ See :doc:`issues` for the need of the various customizations.
 Where is it?
 ************
 
-Latest versions should be at:
-https://bitbucket.org/carlkl/mingw-w64-for-python/downloads
+Latest versions should be at the `mingwpy anaconda site`_.
+
+There are older versions at the `mingwpy bitbucket repo`_.
 
 *************
 What's in it?
@@ -24,77 +25,21 @@ What's in it?
 
 See notes_ below.
 
-#. patches used::
-
-    numpy.patch
-    scipy.patch
-
-#. 64 bit GCC toolchain::
-
-    amd64/
-        mingw-w64-toolchain-static_amd64-gcc-4.8.2_vc90_rev-20140131.7z
-        libpython27.a
-
-   #. numpy-1.8.0 linked against OpenBLAS::
-
-       amd64/numpy-1.8.0/
-           numpy-1.8.0.win-amd64-py2.7.exe
-           numpy-1.8.0-cp27-none-win_amd64.whl
-           numpy_amd64_fcompiler.log
-           numpy_amd64_build.log
-           numpy_amd64_test.log
-           _numpyconfig.h
-           config.h
-
-   #. scipy-0.13.3 linked against OpenBLAS::
-
-       amd64/scipy-0.13.3/
-           scipy-0.13.3.win-amd64-py2.7.exe
-           scipy-0.13.3-cp27-none-win_amd64.whl
-           scipy_amd64_fcompiler.log
-           scipy_amd64_build.log
-           scipy_amd64_build_cont.log
-           scipy_amd64_test._segfault.log
-           scipy_amd64_test.log
-
-#. 32 bit GCC toolchain::
-
-    win32/
-        mingw-w64-toolchain-static_win32-gcc-4.8.2_vc90_rev-20140131.7z
-        libpython27.a
-
-   #. numpy-1.8.0 linked against OpenBLAS::
-
-       win32/numpy-1.8.0/
-           numpy-1.8.0.win32-py2.7.exe
-           numpy-1.8.0-cp27-none-win32.whl
-           numpy_win32_fcompiler.log
-           numpy_win32_build.log
-           numpy_win32_test.log
-           _numpyconfig.h
-           config.h
-
-   #. scipy-0.13.3 linked against OpenBLAS::
-
-       win32/scipy-0.13.3/
-           scipy-0.13.3.win32-py2.7.exe
-           scipy-0.13.3-cp27-none-win32.whl
-           scipy_win32_fcompiler.log
-           scipy_win32_build.log
-           scipy_win32_build_cont.log
-           scipy_win32_test.log
+See :doc:`mingwpy_older` for lists of files in the (older) distribution.
 
 **************************************************
 Customizations over standard mingw-builds releases
 **************************************************
 
-- two dedicated GCC toolchains for both 32bit (POSIX threads, Dwarf exceptions)
-  and 64 bit (POSIX threads, SEH exceptions)
-- statically build toolchain based on gcc-4.8.2 and mingw-w64 v 3.1.0
-- languages: C, C++, gfortran, LTO
-- customized 'specs' file for MSVCR90 linkage and manifest support (MSVCR100 linkage coming soon)
-- additional ftime64 patch to allow winpthreads and OpenMP to work with MSVCR90 linkage
-- openblas-2.9rc1 with windows thread support (OpenMP disabled) included
+- two dedicated GCC toolchains for both 32bit (POSIX threads, Dwarf
+  exceptions) and 64 bit (POSIX threads, SEH exceptions);
+- statically built toolchain based on gcc and mingw-w64;
+- languages: C, C++, gfortran, with :term:`LTO` enabled;
+- customized 'specs' file for MSVCR90 linkage and manifest support (MSVCR100
+  linkage coming soon);
+- additional ftime64 patch to allow winpthreads and OpenMP to work with
+  MSVCR90 linkage;
+- OpenBLAS with windows thread support (OpenMP disabled) included.
 
 .. _notes:
 
@@ -105,11 +50,11 @@ Notes for the distribution
 libpython import files
 ======================
 
-The ``libpython27.a`` import files have been generated with gendef and dlltool
-according to the recommendations on the mingw-w64 faq site. It is essential to
-not use import libraries from anywhere, but create it with the tools in the GCC
-toolchain. The GCC toolchains contains correct generated mscvrXX import files
-per default.
+The ``libpython27.a`` import files have been generated with ``gendef`` and
+``dlltool`` according to the recommendations on the mingw-w64 faq site. It is
+essential to not use import libraries from anywhere, but create them with the
+tools in the GCC toolchain. The GCC toolchains contain correct generated
+``mscvrXXX`` import files by default.
 
 OpenBLAS files
 ==============
@@ -118,11 +63,11 @@ The openblas DLL must be copied to numpy/core before building numpy. All Blas
 and Lapack code will be linked dynamically to this DLL.  Because of this the
 overall distro size gets much smaller compared to numpy-MKL or scipy-MKL. It is
 not necessary to add numpy/core to the path!  (at least on my machine). To load
-libopenblas.dll to the process space it is only necessary to import numpy -
+libopenblas.dll to the process space it is only necessary to import numpy |--|
 nothing else. libopenblas.dll is linked against the msvcr90.dll, just like
-python. The DLL itself is a fat binary containing all optimized kernels for all
-supported platforms. DLL, headers and import files have been included into the
-toolchain.
+python. The DLL itself is a fat binary containing all optimized kernels for
+all supported platforms. DLL, headers and import files have been included into
+the toolchain.
 
 *************************
 Compiling numpy and scipy
@@ -189,3 +134,5 @@ Compiling scipy
 #. test with::
 
         import scipy; scipy.test()
+
+.. include:: links_names.inc

--- a/mingwpy.rst
+++ b/mingwpy.rst
@@ -1,0 +1,191 @@
+####################
+Mingwpy distribution
+####################
+
+***********
+What is it?
+***********
+
+mingwpy is a mingw-w64 gcc toolchain customized for building Python
+extensions.
+
+See :doc:`issues` for the need of the various customizations.
+
+************
+Where is it?
+************
+
+Latest versions should be at:
+https://bitbucket.org/carlkl/mingw-w64-for-python/downloads
+
+*************
+What's in it?
+*************
+
+See notes_ below.
+
+#. patches used::
+
+    numpy.patch
+    scipy.patch
+
+#. 64 bit GCC toolchain::
+
+    amd64/
+        mingw-w64-toolchain-static_amd64-gcc-4.8.2_vc90_rev-20140131.7z
+        libpython27.a
+
+   #. numpy-1.8.0 linked against OpenBLAS::
+
+       amd64/numpy-1.8.0/
+           numpy-1.8.0.win-amd64-py2.7.exe
+           numpy-1.8.0-cp27-none-win_amd64.whl
+           numpy_amd64_fcompiler.log
+           numpy_amd64_build.log
+           numpy_amd64_test.log
+           _numpyconfig.h
+           config.h
+
+   #. scipy-0.13.3 linked against OpenBLAS::
+
+       amd64/scipy-0.13.3/
+           scipy-0.13.3.win-amd64-py2.7.exe
+           scipy-0.13.3-cp27-none-win_amd64.whl
+           scipy_amd64_fcompiler.log
+           scipy_amd64_build.log
+           scipy_amd64_build_cont.log
+           scipy_amd64_test._segfault.log
+           scipy_amd64_test.log
+
+#. 32 bit GCC toolchain::
+
+    win32/
+        mingw-w64-toolchain-static_win32-gcc-4.8.2_vc90_rev-20140131.7z
+        libpython27.a
+
+   #. numpy-1.8.0 linked against OpenBLAS::
+
+       win32/numpy-1.8.0/
+           numpy-1.8.0.win32-py2.7.exe
+           numpy-1.8.0-cp27-none-win32.whl
+           numpy_win32_fcompiler.log
+           numpy_win32_build.log
+           numpy_win32_test.log
+           _numpyconfig.h
+           config.h
+
+   #. scipy-0.13.3 linked against OpenBLAS::
+
+       win32/scipy-0.13.3/
+           scipy-0.13.3.win32-py2.7.exe
+           scipy-0.13.3-cp27-none-win32.whl
+           scipy_win32_fcompiler.log
+           scipy_win32_build.log
+           scipy_win32_build_cont.log
+           scipy_win32_test.log
+
+**************************************************
+Customizations over standard mingw-builds releases
+**************************************************
+
+- two dedicated GCC toolchains for both 32bit (POSIX threads, Dwarf exceptions)
+  and 64 bit (POSIX threads, SEH exceptions)
+- statically build toolchain based on gcc-4.8.2 and mingw-w64 v 3.1.0
+- languages: C, C++, gfortran, LTO
+- customized 'specs' file for MSVCR90 linkage and manifest support (MSVCR100 linkage coming soon)
+- additional ftime64 patch to allow winpthreads and OpenMP to work with MSVCR90 linkage
+- openblas-2.9rc1 with windows thread support (OpenMP disabled) included
+
+.. _notes:
+
+**************************
+Notes for the distribution
+**************************
+
+libpython import files
+======================
+
+The ``libpython27.a`` import files have been generated with gendef and dlltool
+according to the recommendations on the mingw-w64 faq site. It is essential to
+not use import libraries from anywhere, but create it with the tools in the GCC
+toolchain. The GCC toolchains contains correct generated mscvrXX import files
+per default.
+
+OpenBLAS files
+==============
+
+The openblas DLL must be copied to numpy/core before building numpy. All Blas
+and Lapack code will be linked dynamically to this DLL.  Because of this the
+overall distro size gets much smaller compared to numpy-MKL or scipy-MKL. It is
+not necessary to add numpy/core to the path!  (at least on my machine). To load
+libopenblas.dll to the process space it is only necessary to import numpy -
+nothing else. libopenblas.dll is linked against the msvcr90.dll, just like
+python. The DLL itself is a fat binary containing all optimized kernels for all
+supported platforms. DLL, headers and import files have been included into the
+toolchain.
+
+*************************
+Compiling numpy and scipy
+*************************
+
+Compiling numpy
+===============
+
+#. <mingw>\bin and python should be in the PATH. Choose 32 bit or 64 bit architecture.
+#. copy libpython27.a to <python>\libs check, that <python>\libs does not
+   contain libmsvcr90.a
+#. apply numpy.patch
+#. copy libopenblas.dll from <mingw>\bin to numpy\core of course don't ever mix
+   32bit and 64 bit code
+#. create a site.cfg in the numpy folder with the absolute path to the mingw
+   import files/header files. I copied the openblas header files, importlibs
+   into the GCC toolchain.
+#. create a mingw distutils.cfg file
+#. test the configuration::
+
+        python setup.py config_fc --verbose
+        python setup.py build --help-fcompiler
+
+#. build::
+
+        python setup.py build --fcompiler=gnu95
+
+#. make a exe installer::
+
+        python setup.py bdist --format=wininst
+
+#. make a wheel:
+
+   Example for built 32-bit exe installer::
+
+        wininst2wheel numpy-1.8.0.win32-py2.7.exe
+
+#. install::
+
+        wheel install numpy-1.8.0-cp27-none-win32.whl
+
+#. test::
+
+        python -c 'import numpy; numpy.test()'
+
+Compiling scipy
+===============
+
+#. apply scipy.patch
+#. Check fortran compiler with::
+
+        python setup.py build --fcompiler=gnu95
+
+   and a second time::
+
+        python setup.py build --fcompiler=gnu95
+
+#. Build exe installer::
+
+        python setup.py bdist --format=wininst
+
+#. install
+
+#. test with::
+
+        import scipy; scipy.test()

--- a/mingwpy_older.rst
+++ b/mingwpy_older.rst
@@ -1,0 +1,67 @@
+##############################
+Mingwpy retired bitbucket site
+##############################
+
+These lists refer to the older files at the `mingwpy bitbucket repo`_.
+
+#. patches used::
+
+    numpy.patch
+    scipy.patch
+
+#. 64 bit GCC toolchain::
+
+    amd64/
+        mingw-w64-toolchain-static_amd64-gcc-4.8.2_vc90_rev-20140131.7z
+        libpython27.a
+
+   #. numpy-1.8.0 linked against OpenBLAS::
+
+       amd64/numpy-1.8.0/
+           numpy-1.8.0.win-amd64-py2.7.exe
+           numpy-1.8.0-cp27-none-win_amd64.whl
+           numpy_amd64_fcompiler.log
+           numpy_amd64_build.log
+           numpy_amd64_test.log
+           _numpyconfig.h
+           config.h
+
+   #. scipy-0.13.3 linked against OpenBLAS::
+
+       amd64/scipy-0.13.3/
+           scipy-0.13.3.win-amd64-py2.7.exe
+           scipy-0.13.3-cp27-none-win_amd64.whl
+           scipy_amd64_fcompiler.log
+           scipy_amd64_build.log
+           scipy_amd64_build_cont.log
+           scipy_amd64_test._segfault.log
+           scipy_amd64_test.log
+
+#. 32 bit GCC toolchain::
+
+    win32/
+        mingw-w64-toolchain-static_win32-gcc-4.8.2_vc90_rev-20140131.7z
+        libpython27.a
+
+   #. numpy-1.8.0 linked against OpenBLAS::
+
+       win32/numpy-1.8.0/
+           numpy-1.8.0.win32-py2.7.exe
+           numpy-1.8.0-cp27-none-win32.whl
+           numpy_win32_fcompiler.log
+           numpy_win32_build.log
+           numpy_win32_test.log
+           _numpyconfig.h
+           config.h
+
+   #. scipy-0.13.3 linked against OpenBLAS::
+
+       win32/scipy-0.13.3/
+           scipy-0.13.3.win32-py2.7.exe
+           scipy-0.13.3-cp27-none-win32.whl
+           scipy_win32_fcompiler.log
+           scipy_win32_build.log
+           scipy_win32_build_cont.log
+           scipy_win32_test.log
+
+.. include:: links_names.inc


### PR DESCRIPTION
Refactor Mingw-static-toolchain page from numpy wiki, by moving issues
into the `issues` page, and a little rearranging.
