### PR TITLE
Link project to GitHub

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,41 @@
+{%- extends "alabaster/layout.html" %}
+
+{%- block footer %}
+    <div class="footer">
+      {% if show_copyright %}&copy;{{ copyright }}.{% endif %}
+      {% if theme_show_powered_by|lower == 'true' %}
+      {% if show_copyright %}|{% endif %}
+      Powered by <a href="http://sphinx-doc.org/">Sphinx {{ sphinx_version }}</a>
+      &amp; <a href="https://github.com/bitprophet/alabaster">Alabaster {{ alabaster_version }}</a>
+      {% endif %}
+      {%- if show_source and has_source and sourcename %}
+      {% if show_copyright or theme_show_powered_by %}|{% endif %}
+      <a href="{{ pathto('_sources/' + sourcename, true)|e }}"
+          rel="nofollow">{{ _('Page source') }}</a>
+      {%- endif %}
+    </div>
+
+    {% if theme_github_banner|lower != 'false' %}
+    <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}" class="github">
+        <img style="position: absolute; top: 0; right: 0; border: 0;" src="{{ pathto('_static/' ~ theme_github_banner, 1) if theme_github_banner|lower != 'true' else 'https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png' }}" alt="Fork me on GitHub"  class="github"/>
+    </a>
+    {% endif %}
+
+    {% if theme_analytics_id %}
+    <script type="text/javascript">
+
+      var _gaq = _gaq || [];
+      _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
+      _gaq.push(['_setDomainName', 'none']);
+      _gaq.push(['_setAllowLinker', true]);
+      _gaq.push(['_trackPageview']);
+
+      (function() {
+        var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+        ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+        var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+      })();
+
+    </script>
+    {% endif %}
+{%- endblock %}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -10,8 +10,8 @@
       {% endif %}
       {%- if show_source and has_source and sourcename %}
       {% if show_copyright or theme_show_powered_by %}|{% endif %}
-      <a href="{{ pathto('_sources/' + sourcename, true)|e }}"
-          rel="nofollow">{{ _('Page source') }}</a>
+      <a href="https://github.com/{{ theme_github_user }}/{{ theme_github_repo }}/edit/source/{{ pagename }}.rst"
+          rel="nofollow">{{ _('Edit on GitHub') }}</a>
       {%- endif %}
     </div>
 

--- a/conf.py
+++ b/conf.py
@@ -109,14 +109,15 @@ todo_include_todos = False
 
 # -- Options for HTML output ----------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
 html_theme = 'alabaster'
 
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-#html_theme_options = {}
+# Theme options are theme-specific. Alabaster options are documented at
+# https://pypi.python.org/pypi/alabaster
+html_theme_options = {
+    'github_banner': True,
+    'github_user': 'mingwpy',
+    'github_repo': 'mingwpy.github.io',
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []

--- a/conf.py
+++ b/conf.py
@@ -123,6 +123,7 @@ html_theme_options = {
 # http://sphinx-doc.org/config.html#confval-html_sidebars
 html_sidebars = {
    '**': ['localtoc.html', 'searchbox.html'],
+   'index': ['globaltoc.html', 'searchbox.html'],
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/conf.py
+++ b/conf.py
@@ -119,6 +119,12 @@ html_theme_options = {
     'github_repo': 'mingwpy.github.io',
 }
 
+# Templates to render in sidebar, map of document names to templates list.
+# http://sphinx-doc.org/config.html#confval-html_sidebars
+html_sidebars = {
+   '**': ['localtoc.html', 'searchbox.html'],
+}
+
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []
 
@@ -155,9 +161,6 @@ html_static_path = ['_static']
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
 #html_use_smartypants = True
-
-# Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sphinx
+sphinx >= 1.3.2
 ghp-import


### PR DESCRIPTION
This remove "Show Source" from the sidebar, replaces "Show Source" with "Edit on GitHub" link in the footer, adds "Fork me on GitHub" in header, and replaces confusing navigation on the main page with global table of contents.

![image](https://cloud.githubusercontent.com/assets/515889/12014385/7891b72c-ad3c-11e5-9875-07b1273fe293.png)
